### PR TITLE
[fix] remove system 'printf' call.

### DIFF
--- a/srcs/read_input/event_callbacks/print_callback_def.c
+++ b/srcs/read_input/event_callbacks/print_callback_def.c
@@ -1,6 +1,5 @@
 #include "event_callback_def.h"
 #include <libft.h>
-#include <stdio.h>
 #include "utils.h"
 
 void								print_event_callback_def(
@@ -8,8 +7,8 @@ void								print_event_callback_def(
 {
 	if (def != NULL)
 	{
-		printf("id:%d, name:\"%s\", str:\"", def->id, def->name);
+		ft_printf("id:%d, name:\"%s\", str:\"", def->id, def->name);
 		print_non_ascii_str(def->str);
-		printf("\", callback:%p\n", def->callback);
+		ft_printf("\", callback:%p\n", def->callback);
 	}
 }


### PR DESCRIPTION
- replace by 'ft_printf'.
- there is still 'printf' calls. But there are using '%x'.