### PR TITLE
fix - error printing and main_loop history sub

### DIFF
--- a/includes/read_input/editor/editor.h
+++ b/includes/read_input/editor/editor.h
@@ -4,7 +4,6 @@
 # include "read_input/editor/editor_struct.h"
 
 t_editor	*init_editor();
-void		print_string(t_string *s);
 t_editor 	*get_editor();
 void		add_to_string(t_editor *ed, char c);
 char		*get_string_from_list(t_string *s);

--- a/srcs/read_input/editor/editor.c
+++ b/srcs/read_input/editor/editor.c
@@ -53,16 +53,6 @@ void	add_to_string(t_editor *ed, char c)
 	ed->cursor_position++;
 }
 
-void print_string(t_string *s)
-{
-	while (s)
-	{
-		ft_putchar(s->c);
-		s = s->next;
-	}
-	// ft_putchar('\n');
-}
-
 char *get_string_from_list(t_string *s)
 {
 	char 	*str;

--- a/srcs/read_input/event_callbacks/history.c
+++ b/srcs/read_input/event_callbacks/history.c
@@ -31,7 +31,6 @@ EV_CB_RET 	event_history_up(EV_CB_ARGS)
 		ed->need_refresh = true;
 		list_free((t_abstract_list **)&ed->string);
 		str_to_list(ed, ed->history->line);
-		print_string(ed->string);
 		if (ed->history->prev)
 			ed->history = ed->history->prev;
 	}
@@ -45,7 +44,5 @@ EV_CB_RET 	event_history_down(EV_CB_ARGS)
 	{
 		ed->history = ed->history->next;
 		str_to_list(ed, ed->history->line);
-		print_string(ed->string);
-
 	}
 }


### PR DESCRIPTION
Les erreurs de substitution d'historique affichaient 42sh deux fois dans la string a cause d'un modif que j'ai fait + la fonction main_loop ne fonctionnait pas correctement quand history_substitution retournait une erreur.