### PR TITLE
Error print and hist sub fixes

### DIFF
--- a/includes/errors.h
+++ b/includes/errors.h
@@ -37,7 +37,7 @@ typedef struct s_builtin_usage
 t_error const 		*get_error_defs(void);
 void				print_error_msg(t_error_id id);
 void				print_usage_msg(t_builtin_id id);
-
+void				print_name_and_error(t_error_id id);
 
 t_error_id			get_error(void);
 void				set_error(t_error_id error);

--- a/includes/shell_env.h
+++ b/includes/shell_env.h
@@ -23,7 +23,6 @@ OR liste circulaire
 */
 
 # define SHNAME "42sh"
-# define PROMPT "SUprompt> "
 
 typedef struct			s_history
 {

--- a/includes/shell_env.h
+++ b/includes/shell_env.h
@@ -22,7 +22,7 @@ OR liste circulaire
 
 */
 
-# define SHNAME "sh"
+# define SHNAME "42sh"
 # define PROMPT "SUprompt> "
 
 typedef struct			s_history

--- a/srcs/error/print_error.c
+++ b/srcs/error/print_error.c
@@ -2,6 +2,7 @@
 #include "libft.h"
 #include "uint.h"
 #include <stdlib.h>
+#include "shell_env.h"
 
 t_builtin_usage const	*get_builtin_usages()
 {
@@ -33,7 +34,8 @@ void					print_error_msg(t_error_id id)
 
 void					print_name_and_error(t_error_id id)
 {
-	ft_putstr("42sh: ");
+	ft_putstr(SHNAME);
+	ft_putstr(": ");
 	print_error_msg(id);
 }
 

--- a/srcs/error/print_error.c
+++ b/srcs/error/print_error.c
@@ -24,12 +24,17 @@ void					print_error_msg(t_error_id id)
 	{
 		if (id == errors[u].id)
 		{
-			ft_putstr("42sh: ");
 			ft_putendl(errors[u].msg);
 			return;
 		}
 		u++;
 	}
+}
+
+void					print_name_and_error(t_error_id id)
+{
+	ft_putstr("42sh: ");
+	print_error_msg(id);
 }
 
 void					print_usage_msg(t_builtin_id id)

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -11,7 +11,7 @@ static void		main_loop(void)
 	read_input();
 	/*if (get_error() != NO_ERROR)
 		return ;*/
-	if (history_substitution(&get_shell_env()->input_string)
+	if (history_substitution(&get_shell_env()->input_string))
 	{
 		ft_strdel(&get_shell_env()->input_string);
 		return ;

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -32,7 +32,7 @@ int				main(int ac, char **av)
 	init(ac, av);
 	while (get_shell_env()->should_run)
 		main_loop();
-	print_error_msg(get_error());
+	print_name_and_error(get_error());
 	if (get_error() == NO_ERROR)
 		return (EXIT_SUCCESS);
 	else

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -11,7 +11,11 @@ static void		main_loop(void)
 	read_input();
 	/*if (get_error() != NO_ERROR)
 		return ;*/
-	history_substitution(&get_shell_env()->input_string);
+	if (history_substitution(&get_shell_env()->input_string)
+	{
+		ft_strdel(&get_shell_env()->input_string);
+		return ;
+	}
 	break_input();
 	if (get_error() != NO_ERROR)
 		return ;


### PR DESCRIPTION
Les erreurs de substitution d'historique affichaient 42sh deux fois dans la string a cause d'un modif que j'ai fait + la fonction main_loop ne fonctionnait pas correctement quand history_substitution retournait une erreur.