### PR TITLE
Delete syntax tree

### DIFF
--- a/includes/parse_input/syntax_tree.h
+++ b/includes/parse_input/syntax_tree.h
@@ -24,8 +24,10 @@ typedef struct		s_redirection
 	struct s_redirection	*next;
 	ssize_t					n;
 	t_redir_type			type;
-	char const				*word;
+	char					*word;
 }					t_redirection;
+
+void				delete_redirections(t_redirection **redirs);
 
 typedef struct		s_simple_command
 {
@@ -35,6 +37,8 @@ typedef struct		s_simple_command
 	char					**argv;
 }					t_simple_command;
 
+void				delete_pipeline(t_simple_command **cmds);
+
 typedef struct		s_and_or_list
 {
 	struct s_and_or_list	*next;
@@ -42,10 +46,14 @@ typedef struct		s_and_or_list
 	t_ao_type				separation_type;
 }					t_and_or_list;
 
+void				delete_and_or_list(t_and_or_list **ao_list);
+
 typedef struct		s_command_list
 {
 	struct s_command_list	*next;
 	t_and_or_list			*and_or_list;
 }					t_command_list;
+
+void				delete_command_list(t_command_list **cmd_list);
 
 #endif

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -16,6 +16,7 @@ bool						is_bang(char c);
 char						*str_in_str(char *find, char *str, bool must_start);
 void						str_join_with_space(char **str, char *to_join);
 size_t						number_len(char *str);
+void						free_ptr_array(void *ptr_array);
 
 
 #endif

--- a/includes/variable.h
+++ b/includes/variable.h
@@ -16,5 +16,7 @@ typedef struct			s_variable
 
 t_variable				*create_variable(char *name, char *value
 															, bool exported);
+void					delete_variable(t_variable **var);
+void					delete_all_variables(t_variable **var);	
 
 #endif

--- a/srcs/init/variable.c
+++ b/srcs/init/variable.c
@@ -48,6 +48,27 @@ void		free_variable(t_variable *list)
 	}
 }
 
+void		delete_variable(t_variable **var)
+{
+	free_variable(*var);
+	*var = NULL;
+}
+
+void		delete_all_variables(t_variable **var)
+{
+	t_variable	*it;
+	t_variable	*tmp;
+
+	it = *var;
+	while (it)
+	{
+		tmp = it->next;
+		free_variable(it);
+		it = tmp;
+	}
+	*var = NULL;
+}
+
 void		pop_variable_by_name(t_variable **list, char *name)
 {
 	t_variable *lst;

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -32,6 +32,7 @@ static void		main_loop(void)
 	/*if (get_error() != NO_ERROR)
 		return ;*/
 	//execute_tree();
+	delete_command_list(&get_shell_env()->syntax_tree);
 }
 
 int				main(int ac, char **av)

--- a/srcs/parse_input/delete_command_list.c
+++ b/srcs/parse_input/delete_command_list.c
@@ -1,0 +1,78 @@
+#include "syntax_tree.h"
+#include <libft.h>
+#include "variable.h"
+#include "utils.h"
+
+void	delete_redirections(t_redirection **redirs)
+{
+	t_redirection	*tmp;
+	t_redirection	*it;
+
+	it = *redirs;
+	*redirs = NULL;
+	while (it)
+	{
+		tmp = it;
+		free(tmp->word);
+		redirs = &tmp->next;
+		it = *redirs;
+		*redirs = NULL;
+		free(tmp);
+	}
+}
+
+void	delete_pipeline(t_simple_command **cmds)
+{
+	t_simple_command	*tmp;
+	t_simple_command	*it;
+
+	it = *cmds;
+	*cmds = NULL;
+	while (it)
+	{
+		tmp = it;
+		delete_all_variables(&tmp->assignments);
+		delete_redirections(&tmp->redirections);
+		free_ptr_array(tmp->argv);
+		cmds = &tmp->next;
+		it = *cmds;
+		*cmds = NULL;
+		free(tmp);
+	}
+}
+
+void	delete_and_or_list(t_and_or_list **ao_list)
+{
+	t_and_or_list	*tmp;
+	t_and_or_list	*it;
+
+	it = *ao_list;
+	*ao_list = NULL;
+	while (it)
+	{
+		tmp = it;
+		delete_pipeline(&tmp->pipeline);
+		ao_list = &tmp->next;
+		it = *ao_list;
+		*ao_list = NULL;
+		free(tmp);
+	}
+}
+
+void	delete_command_list(t_command_list **cmd_list)
+{
+	t_command_list	*tmp;
+	t_command_list	*it;
+
+	it = *cmd_list;
+	*cmd_list = NULL;
+	while (it)
+	{
+		tmp = it;
+		delete_and_or_list(&tmp->and_or_list);
+		cmd_list = &tmp->next;
+		it = *cmd_list;
+		*cmd_list = NULL;
+		free(tmp);
+	}
+}

--- a/srcs/parse_input/parse_assignments.c
+++ b/srcs/parse_input/parse_assignments.c
@@ -39,13 +39,17 @@ static t_variable		*create_assignment(t_token const *token)
 	char const	*equal_pos;
 	char		*name;
 	char		*value;
+	t_variable	*result;
 
 	equal_pos = find_assignment_equal(token->str);
 	if (equal_pos == NULL)
 		return (NULL);
 	name = strdup_until(token->str, equal_pos);
 	value = ft_strdup(equal_pos + 1);
-	return (create_variable(name, value, false));
+	result = create_variable(name, value, false);
+	free(name);
+	free(value);
+	return (result);
 }
 
 t_variable				*parse_assignments(t_token const *tokens\

--- a/srcs/parse_input/parse_redirections.c
+++ b/srcs/parse_input/parse_redirections.c
@@ -31,13 +31,19 @@ static t_redirection	*create_redirection(t_token const *tokens, t_token const **
 	if (tokens == NULL || (tokens->type->id != (t_token_id)REDIR_OUTPUT
 					&& tokens->type->id != (t_token_id)REDIR_INPUT
 					&& tokens->type->id != (t_token_id)APPEND_OUTPUT))
+	{
+		free(result)
 		return (NULL);
+	}
 	if (result->n == -1)
 		result->n = get_default_fd((t_redir_type)tokens->type->id);
 	result->type = (t_redir_type)tokens->type->id;
 	tokens = tokens->next;
 	if (tokens == NULL || tokens->type->id != TOKEN_TOKID)
+	{
+		free(result);
 		return (NULL);
+	}
 	result->word = ft_strdup(tokens->str);
 	*end = tokens->next;
 	return (result);

--- a/srcs/parse_input/parse_redirections.c
+++ b/srcs/parse_input/parse_redirections.c
@@ -32,7 +32,7 @@ static t_redirection	*create_redirection(t_token const *tokens, t_token const **
 					&& tokens->type->id != (t_token_id)REDIR_INPUT
 					&& tokens->type->id != (t_token_id)APPEND_OUTPUT))
 	{
-		free(result)
+		free(result);
 		return (NULL);
 	}
 	if (result->n == -1)

--- a/srcs/read_input/edit_input.c
+++ b/srcs/read_input/edit_input.c
@@ -57,6 +57,7 @@ void free_editor(t_editor *ed)
 {
 	free_string(ed->string);
 	free(ed->prompt);
+	free(ed->term);
 }
 
 char *edit_input()

--- a/srcs/read_input/editor/gen_prompt.c
+++ b/srcs/read_input/editor/gen_prompt.c
@@ -61,12 +61,15 @@ static char			*mangle_home(char *str)
 {
 	char	*result;
 	char	*home_str;
+	size_t	home_str_len;
 
 	home_str = get_variable("HOME");
 	result = ft_strstr(str, home_str);
+	home_str_len = ft_strlen(home_str);
+	free(home_str);
 	if (result == NULL)
 		return (str);
-	result = ft_strjoin("~", result + ft_strlen(home_str));
+	result = ft_strjoin("~", result + home_str_len);
 	free(str);
 		return(result);
 }
@@ -84,9 +87,9 @@ char				*gen_prompt(void)
 		result = ft_strjoin(" ", tmp);
 		free(tmp);
 		tmp = ft_strjoinf(get_variable("USER"), "@", 1);
-		tmp = ft_strjoinf(tmp, get_hostname(), 2);
-		tmp = ft_strjoinf(ft_strdup("["), tmp, 2);
-		result = ft_strjoinf(tmp, result, 2);
+		tmp = ft_strjoinf(tmp, get_hostname(), 3);
+		tmp = ft_strjoinf("[", tmp, 2);
+		result = ft_strjoinf(tmp, result, 3);
 	}
 	else
 	 	result = ft_strjoin(get_unmatched_str(shell_env->last_unmatched), "> ");

--- a/srcs/utils/free_ptr_array.c
+++ b/srcs/utils/free_ptr_array.c
@@ -1,0 +1,17 @@
+#include "utils.h"
+
+void	free_ptr_array(void *ptr_array)
+{
+	void	**it;
+
+	if (ptr_array != NULL)
+	{
+		it = ptr_array;
+		while (*it != NULL)
+		{
+			free(*it);
+			it++;
+		}
+		free(ptr_array);
+	}
+}


### PR DESCRIPTION
```
 ✘ n0iz@arch-vm  ~/Projects/42sh   delete_syntax_tree  valgrind --leak-check=full ./42sh
==13686== Memcheck, a memory error detector
==13686== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==13686== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info
==13686== Command: ./42sh
==13686== 
[n0iz@arch-vm ~/Projects/42sh]$ bli
command: bli
[n0iz@arch-vm ~/Projects/42sh]$ bla
command: bla
[n0iz@arch-vm ~/Projects/42sh]$ blu
command: blu
[n0iz@arch-vm ~/Projects/42sh]$ bli && blo | var=val bla <file ; cmd
command_list:
  and_or_list:
    command: bli
  &&
    pipeline:
      command: blo
    |
      command: bla
      assignment(s): var=val
      redirection(s): 0 < file
;
  command: cmd
[n0iz@arch-vm ~/Projects/42sh]$ 

```