### PR TITLE
[fix] history: fix invalid read of size with 'strtrim'.

### DIFF
--- a/libft/src/ft_strtrim.c
+++ b/libft/src/ft_strtrim.c
@@ -25,7 +25,7 @@ char	*ft_strtrim(char const *s)
 	end = ft_strlen(s) - 1;
 	while (s[end] == 9 || s[end] == 10 || s[end] == 32)
 		end--;
-	if (end < 0)
-		end = 0;
+	if (end == (int)ft_strlen(s))
+		return (ft_strdup(""));
 	return (ft_strsub(s, i, end - i + 1));
 }


### PR DESCRIPTION
I modified `ft_strtrim()` to looks like mine.
It pass `moulitest`.

Error detected with `valgrind`:

```bash
==28513== Invalid read of size 1
==28513==    at 0x40AE9A: ft_strtrim (ft_strtrim.c:26)
==28513==    by 0x401D79: event_history_up (history.c:38)
==28513==    by 0x4011C2: edit_input (edit_input.c:97)
==28513==    by 0x40130A: handle_stdin (read_input.c:24)
==28513==    by 0x401256: read_input (read_input.c:35)
==28513==    by 0x40956C: main_loop (main.c:16)
==28513==    by 0x40950E: main (main.c:44)
==28513==  Address 0x586e55f is 1 bytes before a block of size 2 alloc'd
==28513==    at 0x4C2DB9D: malloc (vg_replace_malloc.c:299)
==28513==    by 0x40B399: memalloc_or_die (memalloc_or_die.c:7)
==28513==    by 0x409984: ft_strdup (ft_strdup.c:24)
==28513==    by 0x404697: create_history_entry (load_history.c:26)
==28513==    by 0x4095B3: main_loop (main.c:24)
==28513==    by 0x40950E: main (main.c:44)
```

The case modified is to handle empty string.
With previous code, it looks like:
```bash
return (ft_strsub(s, 0, 0 - 0 + 1))
```
which caused `invalid read of size 1`.