### PR TITLE
fix execute double shell

### DIFF
--- a/srcs/execution/execute_pipeline.c
+++ b/srcs/execution/execute_pipeline.c
@@ -25,7 +25,7 @@ t_error_id	execute_file(t_simple_command *cmd, size_t lvl)
 		print_n_char_fd(' ', (lvl + 1) * 2, 2);
 #endif
 		print_errno_error(errno, cmd->argv[0], NULL);
-		ret = errno;
+		exit(EXIT_FAILURE);
 	}
 	else
 	{


### PR DESCRIPTION
Before:
```
 n0iz@nomad  ~/Projects/42sh   master  ./42sh 
[n0iz@nomad ~/Projects/42sh]$ qsdqsd
42sh: qsdqsd: No such file or directory
[n0iz@nomad ~/Projects/42sh]$ exit
  executing builtin exit
[n0iz@nomad ~/Projects/42sh]$ exit
  executing builtin exit
 n0iz@nomad  ~/Projects/42sh   master  
```
After:
```
 ✘ n0iz@nomad  ~/Projects/42sh   fix_execute_double_shell  ./42sh
[n0iz@nomad ~/Projects/42sh]$ qsdqsd
42sh: qsdqsd: No such file or directory
[n0iz@nomad ~/Projects/42sh]$ exit
  executing builtin exit
 n0iz@nomad  ~/Projects/42sh   fix_execute_double_shell  
```