### PR TITLE
[mod] libft: tablen: do not return '-1' if chart is NULL.

### DIFF
--- a/libft/src/ft_tablen.c
+++ b/libft/src/ft_tablen.c
@@ -14,15 +14,11 @@
 
 int		ft_tablen(char **tab)
 {
-	int i;
+	int		i;
 
 	i = 0;
-	if (tab[0])
-	{
-		while (tab[i])
+	if (tab != NULL)
+		while (tab[i] != NULL)
 			i++;
-		return (i);
-	}
-	else
-		return (-1);
+	return (i);
 }


### PR DESCRIPTION
It won't affect other functions:
```bash
grep -rn "ft_tablen(" srcs/ | grep -v Fichier
srcs/init/init.c:20:		if (line && ft_tablen(line) == 2 &&
srcs/execution/execute_builtin.c:26:		ret = builtin->builtin(ft_tablen(cmd->argv), cmd->argv);
srcs/execution/builtins/tabenv.c:42:	nenv = (char**)memalloc_or_die(sizeof(char*) * (ft_tablen(env) + 2));
srcs/execution/builtins/tabenv.c:67:	nenv = (char**)memalloc_or_die(sizeof(char*) * (ft_tablen(env) + 1));
```

I need it it to allocate memory with two upper lines.
If it return `-1` the allocated memory space is not enough.