### PR TITLE
Revert pass envp to builtins

### DIFF
--- a/includes/execution/builtins/builtins.h
+++ b/includes/execution/builtins/builtins.h
@@ -7,7 +7,7 @@
 # define STATUS_SUCCESS 0
 # define STATUS_FAILURE -1
 # define BUILTIN_RET int
-# define BUILTIN_ARGS int argc, char **argv, char **envp
+# define BUILTIN_ARGS int argc, char **argv
 
 typedef BUILTIN_RET	(*t_builtin)(BUILTIN_ARGS);
 
@@ -35,7 +35,7 @@ int 		unsetenv_as(t_variable **env, char *name);
 ** echo
 */
 
-int			builtin_echo(BUILTIN_ARGS);
+int			builtin_echo(int argc, char **argv);
 bool		escape_char(char *str);
 bool		escape(int c);
 int			octal(char *c);

--- a/srcs/execution/builtins/cd.c
+++ b/srcs/execution/builtins/cd.c
@@ -19,7 +19,6 @@ static char			*get_path(int argc, char **argv)
 
 BUILTIN_RET 		builtin_cd(BUILTIN_ARGS)
 {
-	(void)envp;
 	int		ret;
 	char	*new_pwd;
 	char	*old_pwd;

--- a/srcs/execution/builtins/echo.c
+++ b/srcs/execution/builtins/echo.c
@@ -9,9 +9,8 @@
 ** '-s' option: do not display space for last str
 */
 
-BUILTIN_RET		builtin_echo(BUILTIN_ARGS)
+int		builtin_echo(int argc, char **argv)
 {
-	(void)envp;
 	int		i;
 	char		*opt;
 

--- a/srcs/execution/builtins/exit.c
+++ b/srcs/execution/builtins/exit.c
@@ -5,7 +5,6 @@
 
 BUILTIN_RET 		builtin_exit(BUILTIN_ARGS)
 {
-	(void)envp;
 	t_uchar	ret;
 
 	if (argc > 1)

--- a/srcs/execution/builtins/export.c
+++ b/srcs/execution/builtins/export.c
@@ -70,7 +70,6 @@ static void		export_option_p(t_variable *env)
 
 BUILTIN_RET		builtin_export(BUILTIN_ARGS)
 {
-	(void)envp;
 	t_variable	**env;
 	char		*opt;
 	bool		allowed;

--- a/srcs/execution/builtins/set.c
+++ b/srcs/execution/builtins/set.c
@@ -10,7 +10,6 @@
 
 BUILTIN_RET		builtin_set(BUILTIN_ARGS)
 {
-	(void)envp;
 	t_variable	**env;
 
 	env = &get_shell_env()->variables;

--- a/srcs/execution/builtins/setenv.c
+++ b/srcs/execution/builtins/setenv.c
@@ -10,7 +10,6 @@
 
 BUILTIN_RET		builtin_setenv(BUILTIN_ARGS)
 {
-	(void)envp;
 	t_variable	**env;
 
 	env = &get_shell_env()->variables;

--- a/srcs/execution/builtins/unset.c
+++ b/srcs/execution/builtins/unset.c
@@ -80,7 +80,6 @@ static void		unset_option_v(t_variable **env, char **argv)
 
 BUILTIN_RET		builtin_unset(BUILTIN_ARGS)
 {
-	(void)envp;
 	t_variable	**env;
 	char		*opt;
 

--- a/srcs/execution/builtins/unsetenv.c
+++ b/srcs/execution/builtins/unsetenv.c
@@ -8,7 +8,6 @@
 
 BUILTIN_RET		builtin_unsetenv(BUILTIN_ARGS)
 {
-	(void)envp;
 	t_variable	**env;
 	size_t		i;
 

--- a/srcs/execution/execute_builtin.c
+++ b/srcs/execution/execute_builtin.c
@@ -8,7 +8,6 @@ t_error_id	execute_builtin(t_simple_command *cmd, size_t lvl)
 {
 	t_error_id				ret;
 	t_builtin_def const		*builtin;
-	char		**env;
 
 	ret = NO_ERROR;
 	if (cmd != NULL)
@@ -24,9 +23,7 @@ t_error_id	execute_builtin(t_simple_command *cmd, size_t lvl)
 			dprintf(2, "%s is undefined\n", builtin->name);
 			return (NO_SUCH_BUILTIN);
 		}
-		env = get_variables_for_execution(cmd->assignments);
-		ret = builtin->builtin(ft_tablen(cmd->argv), cmd->argv, env);
-		ft_freetabchar(env);
+		ret = builtin->builtin(ft_tablen(cmd->argv), cmd->argv);
 		print_n_char_fd(' ', (lvl) * 2, 2);
 		dprintf(2, "done executing builtin %s, %s\n", builtin->name, ret == NO_ERROR ? "ok" : "error");
 	}

--- a/srcs/history/builtin/history.c
+++ b/srcs/history/builtin/history.c
@@ -37,9 +37,8 @@ static void		hist_parse_options(int argc, char **argv, t_hist_opt *options)
 	}
 }
 
-BUILTIN_RET		builtin_history(BUILTIN_ARGS)
+int				builtin_history(int argc, char **argv)
 {
-	(void)envp;
 	int			i;
 	t_history	*history;
 	t_hist_opt	options;

--- a/tests/srcs/history/history.c
+++ b/tests/srcs/history/history.c
@@ -46,7 +46,7 @@ void	history_print()
 	char	*av[] = {"history"};
 	// int ret;
 
-	builtin_history(1, av, NULL);
+	builtin_history(1, av);
 }
 
 void	history_print_offset()
@@ -57,9 +57,9 @@ void	history_print_offset()
 					};
 	// int ret;
 
-	builtin_history(2, av[0], NULL);
+	builtin_history(2, av[0]);
 	// CU_ASSERT_EQUAL(ret, 0)
-	builtin_history(2, av[1], NULL);
+	builtin_history(2, av[1]);
 	// CU_ASSERT_NOT_EQUAL(get_error(), 0);
 
 }
@@ -75,7 +75,7 @@ void	history_delete()
 
 	nb = list_count((t_abstract_list *)get_shell_env()->history.list) - 1;
 	//printf("nb: %zu\n", nb);
-	builtin_history(2, av[0], NULL);
+	builtin_history(2, av[0]);
 	CU_ASSERT_EQUAL(nb, list_count((t_abstract_list *)get_shell_env()->history.list));
 	nb--;
 
@@ -84,7 +84,7 @@ void	history_delete()
 		print_history(get_shell_env()->history.list, 0);
 	#endif
 
-	builtin_history(3, av[1], NULL);
+	builtin_history(3, av[1]);
 	CU_ASSERT_EQUAL(nb, list_count((t_abstract_list *)get_shell_env()->history.list));
 
 	#ifdef HISTORY_TEST_VERBOSE
@@ -102,7 +102,7 @@ void	history_to_file()
 						{"history", "-a", NULL, NULL} // should append not already appended lines
 					};
 
-	builtin_history(3, av[0], NULL);
+	builtin_history(3, av[0]);
 	CU_ASSERT_NOT_EQUAL(open("test", O_RDONLY), -1);
 
 	#ifdef HISTORY_TEST_VERBOSE
@@ -111,8 +111,8 @@ void	history_to_file()
 		print_history(get_shell_env()->history.list, 0);
 	#endif
 
-	builtin_history(3, av[1], NULL);
-	builtin_history(2, av[2], NULL);
+	builtin_history(3, av[1]);
+	builtin_history(2, av[2]);
 }
 
 void	history_from_file()
@@ -131,7 +131,7 @@ void	history_from_file()
 		print_history(history, 0);
 	#endif
 
-	builtin_history(2, av[0], NULL);
+	builtin_history(2, av[0]);
 
 	#ifdef HISTORY_TEST_VERBOSE
 		ft_printf("State of history list after reading %s\n: ", HISTFILE);
@@ -139,7 +139,7 @@ void	history_from_file()
 	#endif
 	CU_ASSERT_PTR_NOT_NULL(get_shell_env()->history.list);
 	history = get_shell_env()->history.list;
-	builtin_history(3, av[1], NULL);
+	builtin_history(3, av[1]);
 	#ifdef HISTORY_TEST_VERBOSE
 		ft_printf("State of history list after reading %s\n: ", "test");
 		print_history(get_shell_env()->history.list, 0);
@@ -153,7 +153,7 @@ void	history_clear()
 	char *av[] = {"history", "-c"};
 
 
-	builtin_history(2, av, NULL);
+	builtin_history(2, av);
 	CU_ASSERT_PTR_NULL(get_shell_env()->history.list);
 	#ifdef HISTORY_TEST_VERBOSE
 		ft_putendl("State of history after clearing all (should be empty!):");
@@ -174,7 +174,7 @@ void 	history_s_option()
 		print_history(get_shell_env()->history.list, 0);
 	#endif
 
-	builtin_history(5, av[0], NULL);
+	builtin_history(5, av[0]);
 	history = get_shell_env()->history.list;
 
 	while (history->next)
@@ -186,7 +186,7 @@ void 	history_s_option()
 		print_history(get_shell_env()->history.list, 1);
 	#endif
 
-	builtin_history(3, av[1], NULL);
+	builtin_history(3, av[1]);
 	// new = get_shell_env()->history;
 	// list_goto_last((t_abstract_list **)&new);
 	// CU_ASSERT_PTR_EQUAL(history, new);
@@ -215,7 +215,7 @@ void 	history_p_option()
 	while (history->next)
 		history = history->next;
 
-	builtin_history(4, av[0], NULL);
+	builtin_history(4, av[0]);
 	// new = get_shell_env()->history;
 	// list_goto_last((t_abstract_list **)&new);
 	// CU_ASSERT_PTR_EQUAL(history, new);
@@ -226,7 +226,7 @@ void 	history_p_option()
 	#endif
 
 	/*
-		builtin_history(2, av[1], NULL);
+		builtin_history(2, av[1]);
 	 	CU_ASSERT_STRING_EQUAL(history->next->line, "history -p");
 	 */
 }
@@ -241,9 +241,9 @@ void	history_errors()
 						{"history", "-d", "8797"}
 						};
 
-	builtin_history(2, av[0], NULL);
-	// builtin_history(2, av[1], NULL);
-	// builtin_history(3, av[2], NULL);
-	builtin_history(3, av[3], NULL);
-	builtin_history(3, av[4], NULL);
+	builtin_history(2, av[0]);
+	// builtin_history(2, av[1]);
+	// builtin_history(3, av[2]);
+	builtin_history(3, av[3]);
+	builtin_history(3, av[4]);
 }


### PR DESCRIPTION
This revert #153.

It's no more needed for new implementation of `env` builtin.