### PR TITLE
simple tilde expansion (+ move add_quotes to utils)

### DIFF
--- a/includes/expansion/expansion.h
+++ b/includes/expansion/expansion.h
@@ -14,5 +14,6 @@ t_strlist			*field_splitting(char const *word);
 char				*parameter_expansion(char const *word);
 void				quote_removal(char **word);
 void 				handle_quotes(char c, char *quoted);
+char				*tilde_expansion(char const *word);
 
 #endif

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -40,5 +40,7 @@ bool					is_an_argument(char **argv, int pos);
 bool					check_only_allowed_option(char *option, char *allowed);
 size_t					number_of_argument(char **argv);
 void					*sig_handler(int sig);
+void					quote_word(char **word);
+void					quote_per_word(char **str);
 
 #endif

--- a/srcs/expansion/expansion.c
+++ b/srcs/expansion/expansion.c
@@ -50,10 +50,11 @@ static t_strlist	*expand_cmd_word(char const *word)
 	result = NULL;
 	if (word != NULL)
 	{
-		/*str = tilde_expansion(word);
-		tmp = str;*/
-		str = parameter_expansion(word);
+		str = tilde_expansion(word);
 		// tmp = str;
+		tmp = parameter_expansion(str);
+		ft_strdel(&str);
+		str = tmp;
 		if (!str)
 			return (NULL);
 		tmp = command_substition(str);

--- a/srcs/expansion/field_splitting.c
+++ b/srcs/expansion/field_splitting.c
@@ -14,10 +14,11 @@ static void		end_of_quote(char const *word, t_range *delimit)
 
 	quote = *word;
 	delimit->end++;
+	if (quote == '\\')
+		return ;
 	while (word[delimit->end] && (word[delimit->end] != quote \
-			|| (word[delimit->end - 1] && word[delimit->end - 1] == '\\'))) // && ! backslashed
+			|| (word[delimit->end - 1] && word[delimit->end - 1] == '\\')))
 		delimit->end++;
-//	ft_printf("quote end: %d\n", delimit->end);
 }
 
 static void		skip_posix_blanks(char const *word, int *i)

--- a/srcs/expansion/tilde_expansion.c
+++ b/srcs/expansion/tilde_expansion.c
@@ -1,0 +1,33 @@
+#include "expansion.h"
+#include "variable.h"
+#include <libft.h>
+#include "utils.h"
+
+static bool		has_tilde_prefix(char const *word)
+{
+	if (*word++ == '~' && (!*word || *word == '/'))
+		return (true);
+	return (false);
+}
+
+char			*tilde_expansion(char const *word)
+{
+	char	*home_path;
+	char	*result;
+
+	if (has_tilde_prefix(word))
+	{
+		if ((home_path = get_variable("HOME")))
+		{
+			result = ft_strjoin(home_path, word + 1);
+			ft_strdel(&home_path);
+			quote_word(&result);
+		}
+		else
+			// HOME not set error? ("If HOME is unset, the results are unspecified")
+			result = ft_strdup(word);
+	}
+	else
+		result = (ft_strdup(word));
+	return (result);
+}

--- a/srcs/utils/add_quotes.c
+++ b/srcs/utils/add_quotes.c
@@ -1,6 +1,6 @@
 #include "utils.h"
-#include "history_substitutions.h"
-#include "string_substitution.h"
+#include "abstract_list.h"
+#include "read_input/editor/editor.h"
 
 static void		add_quoted_backslash(char **word, size_t first)
 {


### PR DESCRIPTION
```
[ChezLouise@ ~/Documents/42/42sh]$ echo ~
  executing builtin echo
/Users/ChezLouise
  done executing builtin echo, ok
[ChezLouise@ ~/Documents/42/42sh]$ echo ~/test
  executing builtin echo
/Users/ChezLouise/test
  done executing builtin echo, ok
[ChezLouise@ ~/Documents/42/42sh]$ echo "~"
  executing builtin echo
~
  done executing builtin echo, ok
[ChezLouise@ ~/Documents/42/42sh]$ echo '~'
  executing builtin echo
~
  done executing builtin echo, ok
[ChezLouise@ ~/Documents/42/42sh]$ echo \~
  executing builtin echo
~
  done executing builtin echo, ok
[ChezLouise@ ~/Documents/42/42sh]$ echo ~toto
  executing builtin echo
~toto
  done executing builtin echo, ok
[ChezLouise@ ~/Documents/42/42sh]$ echo ~\/test
  executing builtin echo
~/test
  done executing builtin echo, ok
[ChezLouise@ ~/Documents/42/42sh]$ unsetenv HOME
  executing builtin unsetenv
  done executing builtin unsetenv, ok
[ChezLouise@ ~/Users/ChezLouise/Documents/42/42sh]$ echo ~
  executing builtin echo
~
  done executing builtin echo, ok
```

(the last one is an unspecified behavior, I can print a "HOME not set" error message instead, as you wish!)