### PR TITLE
set_last_exit_status for builtins

### DIFF
--- a/srcs/execution/execute_builtin.c
+++ b/srcs/execution/execute_builtin.c
@@ -29,5 +29,6 @@ t_error_id	execute_builtin(t_simple_command *cmd, size_t lvl)
 		print_n_char_fd(' ', (lvl) * 2, 2);
 		dprintf(2, "done executing builtin %s, %s\n", builtin->name, ret == NO_ERROR ? "ok" : "error");
 	}
+	set_last_exit_status(ret == NO_ERROR ? 0 : 1);
 	return (ret);
 }

--- a/srcs/utils/last_exit_status.c
+++ b/srcs/utils/last_exit_status.c
@@ -22,7 +22,10 @@ void			set_last_exit_status(t_uchar status)
 	char *st;
 
 	st = ft_itoa(status);
-	setenv_as(&get_shell_env()->variables, "?", st, true);
+	#ifdef FTSH_DEBUG
+		ft_dprintf(2, "setting last exit status to %s\n", st);
+	#endif
+	set_variable("?", st, false);
 	free(st);
 	*get_ptr() = status;
 }


### PR DESCRIPTION
+ set_variable instead of setenv_as ('?' is non-overwritable)
- Fix #167 