### PR TITLE
handle command line only containing assignments

### DIFF
--- a/includes/variable.h
+++ b/includes/variable.h
@@ -18,6 +18,7 @@ char					*get_variable(char *var);
 void					set_variable(char const *var, char const *val, bool overwrite);
 void					display_variables(bool only_exported);
 char					**get_variables_for_execution(t_variable *assignments);
+void					set_assignments(t_variable *assignments);
 
 t_variable				*create_variable(char const *name, char const *value,
 											bool exported, bool overwrite);

--- a/srcs/variables/set_variable.c
+++ b/srcs/variables/set_variable.c
@@ -23,3 +23,13 @@ void			set_variable(char const *var, char const *val, bool overwrite)
 	else
 		env = create_variable(var, val, false, overwrite);
 }
+
+
+void			set_assignments(t_variable *assignments)
+{
+	while (assignments)
+	{
+		set_variable(assignments->name, assignments->value, true);
+		assignments = assignments->next;
+	}
+}


### PR DESCRIPTION
+ fix segfault due to setting of underscore

```
[ChezLouise@ ~/Documents/42/42sh]$ echo $toto $tata
  executing builtin echo

  done executing builtin echo, ok
[ChezLouise@ ~/Documents/42/42sh]$ toto=titi tata=tutu && echo $toto $tata
    executing builtin echo
titi tutu
    done executing builtin echo, ok
```