### PR TITLE
Command substitution

### DIFF
--- a/srcs/execution/execute_pipeline.c
+++ b/srcs/execution/execute_pipeline.c
@@ -69,6 +69,8 @@ t_error_id	execute_simple_command(t_simple_command *cmd, size_t lvl)
 		dprintf(2, "expanding simple command %s\n", cmd->argv[0]);
 #endif
 		expand_cmd_words(&cmd->argv);
+		if ((ret = get_error()) != NO_ERROR)
+			return (ret);
 #ifdef FTSH_DEBUG
 		print_n_char_fd(' ', (lvl + 1) * 2, 2);
 		dprintf(2, "done expanding simple command %s\n", cmd->argv[0]);

--- a/srcs/expansion/command_substitution.c
+++ b/srcs/expansion/command_substitution.c
@@ -113,11 +113,6 @@ static t_strlist			*split_subsitutions(char const *word)
 				add_passive_string(&result, passv_str_start, word);
 			subst_end = find_substitution_end(word + 1);
 			add_substitution(&result, word + 1, subst_end);
-			if (get_error() != NO_ERROR)
-			{
-				strlist_delete(&result);
-				return (NULL);
-			}
 			word = subst_end + 1;
 			passv_str_start = word;
 		}

--- a/srcs/expansion/expansion.c
+++ b/srcs/expansion/expansion.c
@@ -97,5 +97,5 @@ void				expand_cmd_words(char ***words_addr)
 	*words_addr = strlist_to_strarray(word_list);
 	strlist_delete(&word_list);
 	if (*words_addr && **words_addr)
-		set_last_exit_status(EXIT_SUCCESS);
+		set_error(NO_ERROR);
 }

--- a/srcs/expansion/expansion.c
+++ b/srcs/expansion/expansion.c
@@ -3,6 +3,8 @@
 #include "strlist.h"
 #include "abstract_list.h"
 #include <libft.h>
+#include "errors.h"
+#include "utils.h"
 
 /*
 2.6 Word Expansions
@@ -61,6 +63,7 @@ static t_strlist	*expand_cmd_word(char const *word)
 		ft_strdel(&str);
 		if (!tmp)
 			return (NULL);
+		set_error(NO_ERROR);
 		result = field_splitting(tmp);
 		ft_strdel(&tmp);
 		it = result;
@@ -93,4 +96,6 @@ void				expand_cmd_words(char ***words_addr)
 	ft_freetabchar(*words_addr);
 	*words_addr = strlist_to_strarray(word_list);
 	strlist_delete(&word_list);
+	if (*words_addr && **words_addr)
+		set_last_exit_status(EXIT_SUCCESS);
 }

--- a/srcs/expansion/field_splitting.c
+++ b/srcs/expansion/field_splitting.c
@@ -72,9 +72,6 @@ t_strlist	*field_splitting(char const *word)
 	}
 	tmp = result;
 	while (tmp)
-	{
-	//	ft_printf("<field>%s</field>\n", tmp->str);
 		tmp = tmp->next;
-	}
 	return (result);
 }

--- a/testraw
+++ b/testraw
@@ -1,5 +1,5 @@
 # THIS IS A COMMENTS.
-# PIPE NOT WORK Ex: ls | ls 
+# PIPE NOT WORK Ex: ls | ls
 
 ###########################################################################
 ################################# BUILTIN #################################
@@ -202,8 +202,8 @@ ls > tmp ; cat tmp ; rm tmp
 ls >> tmp ; cat tmp ; rm tmp
 mkdir 2> tmp; cat tmp ; rm tmp
 mkdir 2>> tmp; cat tmp ; rm tmp
-ls 2> tmp; cat tmp ; rm tmp 
-ls 2>> tmp; cat tmp ; rm tmp 
+ls 2> tmp; cat tmp ; rm tmp
+ls 2>> tmp; cat tmp ; rm tmp
 ls>tmp ; cat tmp ; rm tmp
 ls 1> tmp ; cat tmp
 
@@ -216,7 +216,7 @@ cat < tmp >> /tmp/txt; cat /tmp/txt; rm /tmp/tx
 t
 ### Same file name
 cat < tmp > tmp
-cat < tmp >> tmp 
+cat < tmp >> tmp
 
 #################################
 ############## PIPE #############
@@ -261,6 +261,10 @@ echo `ls`
 echo `error`
 `./error`
 echo `./error`
+echo `echo 'un'` `error` `echo trois`
+echo "`ls`"
+echo "`ls\``"
+echo '`ls`'
 
 #################################
 ############# COMMA #############


### PR DESCRIPTION
- handle backslash
- doesn't exit if error in substitution, exit status updated
- use pre-exec() instead of execute()

```
[ChezLouise@iMac-de-Louise ~/Documents/42/42sh]$ echo `ls\``
>42sh: ls`: no such command.
[ChezLouise@iMac-de-Louise ~/Documents/42/42sh]$ echo $?
0
[ChezLouise@iMac-de-Louise ~/Documents/42/42sh]$ `toto`
>42sh: toto: no such command.
[ChezLouise@iMac-de-Louise ~/Documents/42/42sh]$ echo $?
127
```