### PR TITLE
shell errors now return EXIT_FAILURE by default

### DIFF
--- a/srcs/main.c
+++ b/srcs/main.c
@@ -68,6 +68,6 @@ int				main(int ac, char **av)
 	else
 	{
 		print_name_and_error(get_error());
-		return (get_error());
+		return (EXIT_FAILURE);
 	}
 }

--- a/testraw
+++ b/testraw
@@ -262,6 +262,8 @@ echo `error`
 `./error`
 echo `./error`
 echo `echo 'un'` `error` `echo trois`
+echo `echo 'un'``error``echo trois`
+echo `echo 'un'`et`error`et`echo trois`
 echo "`ls`"
 echo "`ls\``"
 echo '`ls`'
@@ -276,9 +278,9 @@ ls;ls
 cat auteur ; cat auteur
 cat auteur ; cat auteur ; cat auteur
 
-# ;
-# ;;;;;
-#  ; ; ; ;  ;		;
+;
+;;;;;
+; ; ; ;  ;		;
 
 ###########################################################################
 ################################## TRASH ##################################


### PR DESCRIPTION
#219

+ retourne EXIT_FAILURE aulieu de get_error dans le main
+ décomentage des tests

bonus
+ ajout de tests de substitution de commande