### PR TITLE
enable cd tests

### DIFF
--- a/srcs/execution/builtins/cd/canonicalize.c
+++ b/srcs/execution/builtins/cd/canonicalize.c
@@ -11,7 +11,6 @@
 
 static t_strlist	*break_components(char const *path)
 {
-	ft_putendl("---------------------break");
 	char const	*start;
 	t_strlist	*cmpnts;
 	char		*tmp;
@@ -26,7 +25,6 @@ static t_strlist	*break_components(char const *path)
 			path++;
 		tmp = strdup_until(start, path);
 		strlist_append(&cmpnts, tmp);
-		ft_putendl(tmp);
 		free(tmp);
 		if (*path == '\0')
 			start = NULL;
@@ -54,7 +52,6 @@ static bool			comp_is_dot_dot(char const *comp)
 
 static void			remove_dots(t_strlist **cmpnts_addr)
 {
-	ft_putendl("-------------------------remove dots");
 	t_strlist	*component;
 
 	component = *cmpnts_addr;
@@ -68,7 +65,6 @@ static void			remove_dots(t_strlist **cmpnts_addr)
 		}
 		else
 		{
-			ft_putendl(component->str);
 			cmpnts_addr = &component->next;
 		}
 		component = *cmpnts_addr;
@@ -91,7 +87,6 @@ static bool			comp_is_directory(t_strlist *start, t_strlist *end)
 
 static int			try_remove_dot_dots(t_strlist **cmpnts_addr)
 {
-	ft_putendl("-------------------------remove dot dots");
 	t_strlist	*component;
 	t_strlist	*start;
 
@@ -101,31 +96,23 @@ static int			try_remove_dot_dots(t_strlist **cmpnts_addr)
 	{
 		if (comp_is_dot_dot(component->next->str) && component->str[0] != '/' && !comp_is_dot_dot(component->str))
 		{
-			ft_putendl("found dot dot");
 			if (!comp_is_directory(start, component))
-			{
-				ft_putendl_fd("42sh: preceding component wasn't a directory", 2);
 				return (EXIT_FAILURE);
-			}
 			*cmpnts_addr = component->next->next;
 			component->next->next = NULL;
 			strlist_delete(&component);
 		}
 		else
 		{
-			ft_putendl(component->str);
 			cmpnts_addr = &component->next;
 		}
 		component = *cmpnts_addr;
 	}
-	if (component != NULL)
-		ft_putendl(component->str);
 	return (EXIT_SUCCESS);
 }
 
 static void			simplify(t_strlist *components)
 {
-	ft_putendl("-------------------------simplify");
 	size_t	u;
 
 	if (components == NULL)
@@ -171,28 +158,20 @@ static void			simplify(t_strlist *components)
 
 char				*canonicalize_path(char const *path)
 {
-	ft_putendl("-------------------------canonicalize");
 	t_strlist	*components;
 	char		*result;
 
 	if (!path)
 		fatal_error("NULL ptr fed to canonicalize_path()");
-	ft_putendl(path);
 	components = break_components(path);
-	ft_putendl(strlist_to_str(components));
 	remove_dots(&components);
-	ft_putendl(strlist_to_str(components));
 	if (try_remove_dot_dots(&components) == EXIT_FAILURE)
 	{
 		strlist_delete(&components);
 		return (NULL);
 	}
-	ft_putendl(strlist_to_str(components));
 	simplify(components);
-	ft_putendl(strlist_to_str(components));
 	result = strlist_to_str(components);
 	strlist_delete(&components);
-	ft_putendl("-------------------------result");
-	ft_putendl(result);
 	return (result);
 }

--- a/srcs/execution/builtins/cd/cd.c
+++ b/srcs/execution/builtins/cd/cd.c
@@ -21,12 +21,10 @@ static bool			first_comp_is_dot_or_dotdot(char const *str)
 	if ((str[0] == '.' && (str[1] == '/' || str[1] == '\0'))
 			|| (str[0] == '.' && str[1] == '.' && (str[2] == '/' || str[2] == '\0')))
 	{
-		ft_putendl("true");
 		return (true);
 	}
 	else
 	{
-		ft_putendl("false");
 		return (false);
 	}
 }
@@ -195,7 +193,6 @@ BUILTIN_RET 		builtin_cd(BUILTIN_ARGS)
 		{
 			// 5. Starting with the first pathname in the <colon>-separated pathnames of CDPATH (see the ENVIRONMENT VARIABLES section) if the pathname is non-null, test if the concatenation of that pathname, a <slash> character if that pathname did not end with a <slash> character, and the directory operand names a directory. If the pathname is null, test if the concatenation of dot, a <slash> character, and the operand names a directory. In either case, if the resulting string names an existing directory, set curpath to that string and proceed to step 7. Otherwise, repeat this step with the next pathname in CDPATH until all pathnames have been tested.
 			curpath = find_cdpath(directory);
-			ft_putendl("doin five");
 		}
 		// 6. Set curpath to the directory operand.
 		if (curpath == NULL)

--- a/srcs/execution/builtins/cd/cd.c
+++ b/srcs/execution/builtins/cd/cd.c
@@ -151,6 +151,7 @@ BUILTIN_RET 		builtin_cd(BUILTIN_ARGS)
 	char	*new_pwd;
 	char	*current_pwd;
 	t_uchar	opt;
+	int		ret;
 
 	/* If, during the execution of the above steps, the PWD environment variable is set, the OLDPWD environment variable shall also be set to the value of the old working directory (that is the current working directory immediately prior to the call to cd). */
 	current_pwd = getcwd(NULL, 0);
@@ -214,8 +215,8 @@ BUILTIN_RET 		builtin_cd(BUILTIN_ARGS)
 		save_the_day(&curpath);
 	}
 	// 10. The cd utility shall then perform actions equivalent to the chdir() function called with curpath as the path argument. If these actions fail for any reason, the cd utility shall display an appropriate error message and the remainder of this step shall not be executed. If the -P option is not in effect, the PWD environment variable shall be set to the value that curpath had on entry to step 9 (i.e., before conversion to a relative pathname). If the -P option is in effect, the PWD environment variable shall be set to the string that would be output by pwd -P. If there is insufficient permission on the new directory, or on any parent of that directory, to determine the current working directory, the value of the PWD environment variable is unspecified.
-	chdir(curpath);
-	if (errno)
+	ret = chdir(curpath);
+	if (ret == -1)
 		print_errno_error(errno, "cd", curpath);
 	else if (opt != 'P')
 	{
@@ -223,7 +224,9 @@ BUILTIN_RET 		builtin_cd(BUILTIN_ARGS)
 		set_variable("PWD", new_pwd, true);
 	}
 	free(curpath);
-	return (errno);
+	if (ret != 0)
+		ret = 2;
+	return (ret);
 }
 
 /*

--- a/srcs/execution/execute_builtin.c
+++ b/srcs/execution/execute_builtin.c
@@ -77,7 +77,7 @@ t_error_id		execute_builtin(t_simple_command *cmd, size_t lvl)
 			#endif
 				return (NO_SUCH_BUILTIN);
 			}
-			builtin->builtin(ft_tablen(cmd->argv), cmd->argv);
+			ret = builtin->builtin(ft_tablen(cmd->argv), cmd->argv);
 			set_variable("_", cmd->argv[ft_tablen(cmd->argv) - 1], false);
 			#ifdef FTSH_DEBUG
 			print_n_char_fd(' ', (lvl) * 2, 2);

--- a/srcs/execution/execute_builtin.c
+++ b/srcs/execution/execute_builtin.c
@@ -77,7 +77,7 @@ t_error_id		execute_builtin(t_simple_command *cmd, size_t lvl)
 			#endif
 				return (NO_SUCH_BUILTIN);
 			}
-			ret = builtin->builtin(ft_tablen(cmd->argv), cmd->argv);
+			builtin->builtin(ft_tablen(cmd->argv), cmd->argv);
 			set_variable("_", cmd->argv[ft_tablen(cmd->argv) - 1], false);
 			#ifdef FTSH_DEBUG
 			print_n_char_fd(' ', (lvl) * 2, 2);
@@ -90,5 +90,7 @@ t_error_id		execute_builtin(t_simple_command *cmd, size_t lvl)
 	}
 	if (get_error() != ENV_EXEC_ERR)
 		set_last_exit_status(ret);
+	if (ret != 0)
+		ret = CHILD_FAILURE;
 	return (ret);
 }

--- a/testraw
+++ b/testraw
@@ -11,15 +11,15 @@ touch tmp tmp2
 ############### CD ##############
 #################################
 # cd [-L|-P] [directory]
-# cd ; pwd
-# cd ~ ; pwd
-# cd / ; pwd
-# cd - ; pwd
-# cd . ; pwd
-# cd .. ; pwd
-# cd ~/. ; pwd
-# cd nasrt
-# cd auteur
+cd ; pwd
+cd ~ ; pwd
+cd / ; pwd
+cd - ; pwd
+cd . ; pwd
+cd .. ; pwd
+cd ~/. ; pwd
+cd nasrt
+cd auteur
 
 #################################
 ############## ECHO #############


### PR DESCRIPTION
+ enable cd tests
+ remove debug print in cd.c and canonicalize.c
+ fix exit status handling in execute_builtin
+ return 2 if chdir fails in cd, for travis